### PR TITLE
Mount will restart regardless of failure

### DIFF
--- a/systemd/rclone.service
+++ b/systemd/rclone.service
@@ -21,7 +21,7 @@ ExecStart=/usr/bin/rclone mount gcrypt: /GD \
 --vfs-read-chunk-size 32M
 ExecStop=/bin/fusermount -uz /GD
 ExecStartPost=/usr/bin/rclone rc vfs/refresh recursive=true --rc-addr 127.0.0.1:5572 _async=true
-Restart=on-failure
+Restart=always
 User=felix
 Group=felix
 


### PR DESCRIPTION
Earlier, only if there was a failure, `systemctl restart` would kill and start the mount. 

Now, regardless of a failure, the mount will be restarted, which should be the expected behavior when the command is issued.